### PR TITLE
Don't use dr.AUTOPILOT_MODE in Pydantic schemas

### DIFF
--- a/src/pulumi_datarobot_utils/schema/training.py
+++ b/src/pulumi_datarobot_utils/schema/training.py
@@ -199,7 +199,7 @@ class DatetimePartitioningArgs(Schema):
 
 class AnalyzeAndModelArgs(Schema):
     target: Any | None = None
-    mode: dr.AUTOPILOT_MODE = dr.AUTOPILOT_MODE.QUICK
+    mode: str = dr.AUTOPILOT_MODE.QUICK
     metric: Any | None = None
     worker_count: Any | None = None
     positive_class: Any | None = None


### PR DESCRIPTION
# This repository is public. Do not put here any private DataRobot or customer's data: code, datasets, model artifacts, .etc.

## Summary


## Rationale
